### PR TITLE
Merge labels when generated next to each other

### DIFF
--- a/examples/strlwr.con
+++ b/examples/strlwr.con
@@ -5,10 +5,11 @@ function strlwr(str):
 	while byte[str] ne 0:
 		if byte[str] ge 65:
 			if byte[str] le 90:
-				!crntchr sil
-				mov crntchr, byte[str]
-				add crntchr, 32
-				mov byte[str], crntchr
+				if byte[str] ne 95:
+					!crntchr sil
+					mov crntchr, byte[str]
+					add crntchr, 32
+					mov byte[str], crntchr
 		inc str
 
 

--- a/src/construct.cpp
+++ b/src/construct.cpp
@@ -1,8 +1,8 @@
 #include "deconstruct.h"
 #include "reconstruct.h"
 #include "construct_flags.h"
-#include<iostream>
-#include<fstream>
+#include <iostream>
+#include <fstream>
 
 int main(int argc, char** argv) {
   std::string path;
@@ -37,6 +37,7 @@ int main(int argc, char** argv) {
   std::vector<con_macro> empty_macros;
   apply_macros(tokens, empty_macros);
   linearize_tokens(tokens);
+  merge_labels(tokens);
 
   std::ofstream outfile;
   outfile.open(outpath);

--- a/src/construct_debug.h
+++ b/src/construct_debug.h
@@ -1,5 +1,5 @@
-#include<iostream>
-#include<string>
+#include <iostream>
+#include <string>
 #include "construct_types.h"
 #include "reconstruct.h"
 

--- a/src/construct_flags.h
+++ b/src/construct_flags.h
@@ -1,7 +1,8 @@
-#include<string>
-#include<cstring>
-#include<iostream>
+#include <string>
+#include <cstring>
+#include <iostream>
 #include "reconstruct.h"
 
 int set_bitwidth(char* argv);
 int handle_flags(int argc, char** argv, std::string* path, std::string* outpath);
+ 

--- a/src/construct_types.h
+++ b/src/construct_types.h
@@ -1,8 +1,8 @@
 #ifndef CON_TYPES_H
 #define CON_TYPES_H
 
-#include<string>
-#include<vector>
+#include <string>
+#include <vector>
 
 enum CON_BITWIDTH {
   BIT8,

--- a/src/construct_types.h
+++ b/src/construct_types.h
@@ -17,7 +17,8 @@ enum CON_COMPARISON {
   L,
   G,
   LE,
-  GE
+  GE,
+  ERROR,
 };
 
 enum CON_TOKENTYPE {

--- a/src/deconstruct.cpp
+++ b/src/deconstruct.cpp
@@ -47,7 +47,7 @@ CON_COMPARISON str_to_comparison(string comp) {
     return LE;
   if(comp == "ge")
     return GE;
-  //ERROR
+  return ERROR;
 }
 
 

--- a/src/deconstruct.h
+++ b/src/deconstruct.h
@@ -1,11 +1,11 @@
 #include "construct_debug.h"
-#include<boost/algorithm/string/classification.hpp>
-#include<boost/algorithm/string/split.hpp>
-#include<boost/algorithm/string.hpp>
-#include<fstream>
-#include<sstream>
-#include<iostream>
-#include<stack>
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string.hpp>
+#include <fstream>
+#include <sstream>
+#include <iostream>
+#include <stack>
 
 int get_line_indentation(std::string line);
 CON_TOKENTYPE get_token_type(std::string line);

--- a/src/reconstruct.cpp
+++ b/src/reconstruct.cpp
@@ -97,6 +97,7 @@ string reg_to_str(uint8_t call_num, CON_BITWIDTH bitwidth) {
       }
     break;
   }
+  // ERROR
 }
 
 string comparison_to_string(CON_COMPARISON condition) {
@@ -132,6 +133,7 @@ CON_COMPARISON get_comparison_inverse(CON_COMPARISON condition) {
     case GE:
       return L;
   }
+  return ERROR;
 }
 
 void apply_macro_to_token(con_token& token, vector<con_macro> macros) {
@@ -390,7 +392,6 @@ std::string tokens_to_nasm(std::vector<con_token*>& tokens) {
     if(tokens[i]->tok_type == IF || tokens[i]->tok_type == WHILE || tokens[i]->tok_type == FUNCTION || tokens[i]->tok_type == MACRO || tokens[i]->tok_type == FUNCALL) {
       continue;
     }
-    output += "\n";
     if(tokens[i]->tok_type == CMD) {
       output += tokens[i]->tok_cmd->command;
       if(!tokens[i]->tok_cmd->arg1.empty()) {
@@ -399,14 +400,17 @@ std::string tokens_to_nasm(std::vector<con_token*>& tokens) {
       if(!tokens[i]->tok_cmd->arg2.empty()) {
         output += ", " + tokens[i]->tok_cmd->arg2;
       }
+      output += "\n";
       continue;
     }
     if(tokens[i]->tok_type == TAG) {
       output += tokens[i]->tok_tag->name + ":";
+      output += "\n";
       continue;
     }
     if(tokens[i]->tok_type == SECTION) {
       output += "section " + tokens[i]->tok_section->name;
+      output += "\n";
       continue;
     }
   }

--- a/src/reconstruct.h
+++ b/src/reconstruct.h
@@ -1,6 +1,7 @@
-#include<string>
-#include<iostream>
-#include<stdint.h>
+#include <string>
+#include <iostream>
+#include <stdint.h>
+#include <unordered_map>
 #include "construct_types.h"
 
 // Used for naming tags
@@ -25,5 +26,6 @@ void apply_funcalls(std::vector<con_token*>& tokens);
 void apply_whiles(std::vector<con_token*>& tokens);
 void apply_ifs(std::vector<con_token*>& tokens);
 void apply_macros(std::vector<con_token*>& tokens, std::vector<con_macro> macros);
+void merge_labels(std::vector<con_token*>& tokens);
 
 std::string tokens_to_nasm(std::vector<con_token*>& tokens);


### PR DESCRIPTION
When 2 labels are generated together, they are merged into one. Changed an example to have 3 nested if-statements, which otherwise would have generated:
iflabel0:
iflabel1:
iflabel2:
Which is now just
labelN:
As well as being able to merge labels regardless of whether they represent if/while/functions.
I'd like to eventually add an IF macro to allow multiple conditional statements to be included in a (X; Y; Z; ...) format to avoid further nesting

Also fixed minor formatting and most compiler warnings